### PR TITLE
Make the embellishment icon more prominent

### DIFF
--- a/Modules/RetrieveGearInfo.lua
+++ b/Modules/RetrieveGearInfo.lua
@@ -295,15 +295,16 @@ function AddOn:ShowEmbellishmentBySlot(slot, isInspect)
                     if not slot.PGVEmbellishmentShadow then
                         slot.PGVEmbellishmentShadow = slot:CreateTexture("PGVEmbellishmentShadow"..slot:GetID(), "ARTWORK")
                     end
-                    slot.PGVEmbellishmentShadow:SetSize(60, 60)
+                    slot.PGVEmbellishmentShadow:SetSize(40, 45)
                     slot.PGVEmbellishmentShadow:ClearAllPoints()
                     if self.db.profile.showiLvl and self.db.profile.iLvlOnItem then
                         slot.PGVEmbellishmentShadow:SetPoint("BOTTOMLEFT", slot, "BOTTOMLEFT", 0, -9)
                     else
                         slot.PGVEmbellishmentShadow:SetPoint("TOPLEFT", slot, "TOPLEFT", -2, -2)
                     end
+                    -- TODO: Disable the shadow if the embellishment is not visible
                     slot.PGVEmbellishmentShadow:SetTexture("Interface/Buttons/WHITE8x8")
-                    slot.PGVEmbellishmentShadow:SetVertexColor(0, 0, 0, 0.35)
+                    slot.PGVEmbellishmentShadow:SetVertexColor(0, 0, 0, 0.3)
                     slot.PGVEmbellishmentShadow:Show()
 
                     -- Main embellishment star (top layer)


### PR DESCRIPTION
Features:
- Enlarges and slightly repositions the green star in the bottom left corner
- Adds a semi-transparent black layer under the star and above the underlying image

Before:
![Screenshot 2025-07-02 010336](https://github.com/user-attachments/assets/09566603-4330-4152-9901-c735cfa486f4)

After:
![Screenshot 2025-07-02 010216](https://github.com/user-attachments/assets/fd6e215d-d7cd-4f36-82f8-1e32791bdd38)

Todos:
- Need to add functionality to disable the black layer if the star icon is disabled by the user