### PR TITLE
Show/Hide the "Enchant Text" button

### DIFF
--- a/PranGearView.lua
+++ b/PranGearView.lua
@@ -566,6 +566,7 @@ local OptionsTable = {
                         end,
                     disabled = function() return not AddOn.db.profile.showEnchants or (AddOn.db.profile.showEnchants and not AddOn.db.profile.showMissingEnchants) end
                 },
+                -- Options to toggle enchant button visibility
                 showEnchantTextButton = {
                     type = "toggle",
                     name = L["Show/Hide Enchant Text Button"],
@@ -574,8 +575,10 @@ local OptionsTable = {
                     get = function(item) return AddOn.db.profile[item[#item]] end,
                     set = function(item, val)
                         AddOn.db.profile[item[#item]] = val
+                        -- Hide if unchecked
                         if not val and AddOn.PGVToggleEnchantButton:IsShown() then
                             AddOn.PGVToggleEnchantButton:Hide()
+                        -- Show if checked and not already shown
                         elseif val and not AddOn.PGVToggleEnchantButton:IsShown() then
                             AddOn.PGVToggleEnchantButton:Show()
                         end
@@ -1552,6 +1555,13 @@ function AddOn:OnInitialize()
         LibStub("AceConfigRegistry-3.0"):NotifyChange(addonName)
         LibStub("AceConfigRegistry-3.0"):NotifyChange("PGVOptions")
     end)
+
+    -- Always check the box for showing enchant text button when the AddOn is initialized
+    -- Ace3 saves the state of the checkbox but not the button iteself, so it will always be shown
+    -- TODO: Need to ensure the state of the enchant button is saved between sessions
+    if self.db.profile.showEnchantTextButton ~= true then
+        self.db.profile.showEnchantTextButton = true
+    end
 end
 
 ---Handles slash commands in a way that overrides the default behavior of Ace3 slash commands. Executing the command with no arguments

--- a/PranGearView.lua
+++ b/PranGearView.lua
@@ -566,6 +566,22 @@ local OptionsTable = {
                         end,
                     disabled = function() return not AddOn.db.profile.showEnchants or (AddOn.db.profile.showEnchants and not AddOn.db.profile.showMissingEnchants) end
                 },
+                showEnchantTextButton = {
+                    type = "toggle",
+                    name = L["Show/Hide Enchant Text Button"],
+                    desc = L["Toggle the visibility of the enchant text button"],
+                    order = orderCounter(),
+                    get = function(item) return AddOn.db.profile[item[#item]] end,
+                    set = function(item, val)
+                        AddOn.db.profile[item[#item]] = val
+                        if not val and AddOn.PGVToggleEnchantButton:IsShown() then
+                            AddOn.PGVToggleEnchantButton:Hide()
+                        elseif val and not AddOn.PGVToggleEnchantButton:IsShown() then
+                            AddOn.PGVToggleEnchantButton:Show()
+                        end
+                        AddOn:HandleEquipmentOrSettingsChange()
+                    end
+                },
                 spacerTwo = AddOn.CreateOptionsSpacer(orderCounter()),
                 enchTextColorOptionsDesc = {
                     type = "description",
@@ -1295,7 +1311,8 @@ local DBDefaults = {
         hideShirtTabardInfo = false,
         collapseEnchants = false,
         minimap = { hide = true },
-        increaseCharacterInfoSize = true
+        increaseCharacterInfoSize = true,
+        showEnchantTextButton = true
     }
 }
 


### PR DESCRIPTION
Features:
- Adds a menu option to show or hide the enchant text button on the character window

Show:
![Screenshot 2025-07-02 000759](https://github.com/user-attachments/assets/2d0ba624-f02f-4509-b215-b15f226e87b2)

Hide:
![Screenshot 2025-07-02 000817](https://github.com/user-attachments/assets/9994a29e-081a-4e5a-b784-0d6148ce6a6a)

Todos:
- The state of the button itself isn't saved between sessions (load/reload), so the new option is configured to always reset to "show" so it syncs up with the button