### PR TITLE
Fix breaking other addon's settings under certain situations. Fix a tooltip showing up on login

### DIFF
--- a/Modules/ToggleEnchantButton.lua
+++ b/Modules/ToggleEnchantButton.lua
@@ -25,7 +25,6 @@ button:SetScript("OnEnter", function(self) self:UpdateTooltip() end)
 button:SetScript("OnLeave", function()
     GameTooltip:Hide()
 end)
-button:UpdateTooltip()
 
 AddOn.PGVToggleEnchantButton = button
 

--- a/PranGearView.lua
+++ b/PranGearView.lua
@@ -1547,7 +1547,7 @@ function AddOn:OnInitialize()
 
     -- Whenever the options window is opened, clear the lastSelectedSpecID entry from the database so that
     -- it shows the character's current specialization options by default
-    SettingsPanel:SetScript("OnShow", function()
+    SettingsPanel:HookScript("OnShow", function()
         local specID = AddOn.GetCharacterCurrentSpecIDAndRole(AddOn)
         if AddOn.SpecOptionKeys[specID] and specID ~= AddOn.db.profile.lastSelectedSpecID then
             AddOn.db.profile.lastSelectedSpecID = specID


### PR DESCRIPTION
SetScript replaces the script from the default UI, which does a bunch of important stuff
you should generally avoid using SetScript, unless you're 100% sure that it can't hurt